### PR TITLE
fix: reference release workflow by SHA

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ permissions:
 
 jobs:
   release:
-    uses: actions-mn/.github/.github/workflows/metanorma-release.yml@v1
+    uses: actions-mn/.github/.github/workflows/metanorma-release.yml@1e39548
     with:
       default-visibility: private
       include-pattern: ${{ github.event.inputs.include-pattern || '*' }}


### PR DESCRIPTION
Fixes GitHub Actions cache issue by referencing the reusable workflow by commit SHA.